### PR TITLE
Support inline-style overrides for bold tags

### DIFF
--- a/formats/bold.js
+++ b/formats/bold.js
@@ -1,11 +1,19 @@
 import Inline from '../blots/inline';
 
+const NON_BOLD_FONT_WEIGHTS = ['normal', 'lighter'];
+
 class Bold extends Inline {
   static create() {
     return super.create();
   }
 
-  static formats() {
+  static formats(node) {
+    const fontWeightNumber = parseInt(node.style.fontWeight, 10);
+    const isNormalWeight =
+      fontWeightNumber <= 400 ||
+      NON_BOLD_FONT_WEIGHTS.includes(node.style.fontWeight);
+    // If this is a b-tag that is supposed to format normally, just return undefined so no format is not applied.
+    if (isNormalWeight) return undefined;
     return true;
   }
 

--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -35,9 +35,6 @@ const CLIPBOARD_CONFIG = [
   ['ol, ul', matchList],
   ['pre', matchCodeBlock],
   ['tr', matchTable],
-  ['b', matchAlias.bind(matchAlias, 'bold')],
-  ['i', matchAlias.bind(matchAlias, 'italic')],
-  ['strike', matchAlias.bind(matchAlias, 'strike')],
   ['style', matchIgnore],
 ];
 
@@ -336,10 +333,6 @@ function traverse(scroll, node, elementMatchers, textMatchers, nodeMatches) {
     }, new Delta());
   }
   return new Delta();
-}
-
-function matchAlias(format, node, delta) {
-  return applyFormat(delta, format, true);
 }
 
 function matchAttributor(node, delta, scroll) {

--- a/test/unit/modules/clipboard.js
+++ b/test/unit/modules/clipboard.js
@@ -215,6 +215,18 @@ describe('Clipboard', function() {
       );
     });
 
+    it('style overrides', function() {
+      const html =
+        '<b style="font-weight: normal;"><span>one </span><span style="font-weight: bold;">two</span><span> three</span></pre>';
+      const delta = this.clipboard.convert({ html });
+      expect(delta).toEqual(
+        new Delta()
+          .insert('one ')
+          .insert('two', { bold: true })
+          .insert(' three'),
+      );
+    });
+
     it('nested list', function() {
       const delta = this.clipboard.convert({
         html: '<ol><li>One</li><li class="ql-indent-1">Alpha</li></ol>',

--- a/test/unit/modules/clipboard.js
+++ b/test/unit/modules/clipboard.js
@@ -217,7 +217,7 @@ describe('Clipboard', function() {
 
     it('style overrides', function() {
       const html =
-        '<b style="font-weight: normal;"><span>one </span><span style="font-weight: bold;">two</span><span> three</span></pre>';
+        '<b style="font-weight: normal;"><span>one </span><span style="font-weight: bold;">two</span><span> three</span></b>';
       const delta = this.clipboard.convert({ html });
       expect(delta).toEqual(
         new Delta()


### PR DESCRIPTION
This is a fix for https://github.com/quilljs/quill/issues/2462:

1. I removed the alias matchers from the clipboard because as far as I understand all of the use cases are already covered by the blots.
2. Checks for inline overrides to the style and does not return the format for a blot if that's the case.